### PR TITLE
build(config): split tsconfig for build, lint, and test, and update tool configs

### DIFF
--- a/base/configs/base-scripts.json
+++ b/base/configs/base-scripts.json
@@ -4,7 +4,7 @@
     "build": "pnpm run build:cjs && pnpm run build:esm & pnpm run build:types",
     "build:cjs": "tsup --config ./configs/tsup.config.cjs.ts",
     "build:esm": "tsup --config ./configs/tsup.config.esm.ts",
-    "build:types": "tsc -p ./tsconfig.json",
+    "build:types": "tsc -p ./tsconfig.build.json",
     "clean": "rimraf lib module .cache",
     "format:dprint": "dprint fmt",
     "check:dprint": "dprint check",

--- a/packages/@aglabo/agla-error/configs/eslint.config.js
+++ b/packages/@aglabo/agla-error/configs/eslint.config.js
@@ -7,6 +7,15 @@
 // https://opensource.org/licenses/MIT
 
 // libs
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const __rootDir = path.resolve(__dirname, '..'); // packages/@aglabo/ag-logger
+
+// plugins
+// import tseslint from 'typescript-eslint';
 
 // import form common base config
 import baseConfig from '../../../../base/configs/eslint.config.base.js';
@@ -18,15 +27,20 @@ export default [
   // source code settings
   {
     files: [
-      'index.ts',
       'src/**/*.ts',
-      'types/**/*.ts',
+      'shared/**/*.ts',
       'tests/**/*.ts',
     ],
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: __rootDir,
+      },
+    },
     settings: {
       'import/resolver': {
         typescript: {
-          project: './tsconfig.json',
+          project: path.resolve(__rootDir, 'tsconfig.json'),
+          alwaysTryTypes: true,
         },
       },
     },

--- a/packages/@aglabo/agla-error/configs/eslint.config.typed.js
+++ b/packages/@aglabo/agla-error/configs/eslint.config.typed.js
@@ -35,7 +35,6 @@ export default [
     languageOptions: {
       parser: tsparser,
       parserOptions: {
-        project: ['./tsconfig.json'],
         tsconfigRootDir: __rootDir,
         sourceType: 'module',
       },

--- a/packages/@aglabo/agla-error/configs/tsup.config.cjs.ts
+++ b/packages/@aglabo/agla-error/configs/tsup.config.cjs.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   format: ['cjs'],
   outDir: 'lib', // for CJS
   // tsconfig
-  tsconfig: './tsconfig.json',
+  tsconfig: './tsconfig.build.json',
   // DTS with incremental build for CJS
   dts: false,
 });

--- a/packages/@aglabo/agla-error/configs/tsup.config.esm.ts
+++ b/packages/@aglabo/agla-error/configs/tsup.config.esm.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   format: ['esm'],
   outDir: 'module', // for ESM
   // tsconfig
-  tsconfig: './tsconfig.json',
+  tsconfig: './tsconfig.build.json',
   // DTS with incremental build for ESM
   dts: true,
 });

--- a/packages/@aglabo/agla-error/configs/vitest.config.e2e.ts
+++ b/packages/@aglabo/agla-error/configs/vitest.config.e2e.ts
@@ -10,9 +10,13 @@
 import path from 'path';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
+
 // base directory
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const __rootDir = path.relative(__dirname, '../');
+
+// plugins
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 // system config
 import { mergeConfig } from 'vitest/config';
@@ -22,6 +26,7 @@ import baseConfig from '../../../../base/configs/vitest.config.base';
 
 // config
 export default mergeConfig(baseConfig, {
+  plugins: [tsconfigPaths()],
   test: {
     include: [
       // CI (End-to-End) Tests
@@ -36,11 +41,5 @@ export default mergeConfig(baseConfig, {
     sequence: {
       concurrent: true,
     },
-  },
-  resolve: {
-    alias: [
-      { find: '@', replacement: path.resolve(__rootDir, './src') },
-      { find: /^@\/shared/, replacement: path.resolve(__rootDir, './shared') },
-    ],
-  },
+  }
 });

--- a/packages/@aglabo/agla-error/configs/vitest.config.functional.ts
+++ b/packages/@aglabo/agla-error/configs/vitest.config.functional.ts
@@ -13,6 +13,9 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const __rootDir = path.relative(__dirname, '../');
 
+// plugins
+import tsconfigPaths from 'vite-tsconfig-paths';
+
 // system config
 import { mergeConfig } from 'vitest/config';
 
@@ -21,6 +24,7 @@ import baseConfig from '../../../../base/configs/vitest.config.base';
 
 // config
 export default mergeConfig(baseConfig, {
+  plugins: [tsconfigPaths()],
   test: {
     include: [
       // Functional Test - single feature complete behavior verification
@@ -45,11 +49,5 @@ export default mergeConfig(baseConfig, {
         'tests/**',
       ],
     },
-  },
-  resolve: {
-    alias: [
-      { find: '@', replacement: path.resolve(__rootDir, './src') },
-      { find: /^@\/shared/, replacement: path.resolve(__rootDir, './shared') },
-    ],
-  },
+  }
 });

--- a/packages/@aglabo/agla-error/configs/vitest.config.integration.ts
+++ b/packages/@aglabo/agla-error/configs/vitest.config.integration.ts
@@ -13,6 +13,9 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const __rootDir = path.relative(__dirname, '../');
 
+// plugins
+import tsconfigPaths from 'vite-tsconfig-paths';
+
 // system config
 import { mergeConfig } from 'vitest/config';
 
@@ -21,6 +24,7 @@ import baseConfig from '../../../../base/configs/vitest.config.base';
 
 // config
 export default mergeConfig(baseConfig, {
+  plugins: [tsconfigPaths()],
   test: {
     include: [
       // CI (Integration) Tests
@@ -35,11 +39,5 @@ export default mergeConfig(baseConfig, {
     sequence: {
       concurrent: true,
     },
-  },
-  resolve: {
-    alias: {
-      '@/shared': path.resolve(__rootDir, './shared/'),
-      '@': path.resolve(__rootDir, './src'),
-    },
-  },
+  }
 });

--- a/packages/@aglabo/agla-error/configs/vitest.config.unit.ts
+++ b/packages/@aglabo/agla-error/configs/vitest.config.unit.ts
@@ -6,6 +6,9 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// plugins
+import tsconfigPaths from 'vite-tsconfig-paths';
+
 // libs for base directory
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -21,6 +24,7 @@ import baseConfig from '../../../../base/configs/vitest.config.base';
 
 // config
 export default mergeConfig(baseConfig, {
+  plugins: [tsconfigPaths()],
   test: {
     include: [
       // Unit Test - pure unit tests for individual functions/methods
@@ -45,11 +49,5 @@ export default mergeConfig(baseConfig, {
         'tests/**',
       ],
     },
-  },
-  resolve: {
-    alias: [
-      { find: '@', replacement: path.resolve(__rootDir, './src') },
-      { find: /^@\/shared/, replacement: path.resolve(__rootDir, './shared') },
-    ],
-  },
+  }
 });

--- a/packages/@aglabo/agla-error/package.json
+++ b/packages/@aglabo/agla-error/package.json
@@ -20,7 +20,7 @@
     "build": "pnpm run build:cjs && pnpm run build:esm & pnpm run build:types",
     "build:cjs": "tsup --config ./configs/tsup.config.cjs.ts",
     "build:esm": "tsup --config ./configs/tsup.config.esm.ts",
-    "build:types": "tsc -p ./tsconfig.json",
+    "build:types": "tsc -p ./tsconfig.build.json",
     "clean": "rimraf lib module .cache",
     "format:dprint": "dprint fmt",
     "check:dprint": "dprint check",

--- a/packages/@aglabo/agla-error/tsconfig.build.json
+++ b/packages/@aglabo/agla-error/tsconfig.build.json
@@ -10,13 +10,15 @@
   "include": [
     "src/**/*.ts",
     "shared/**/*.ts",
-    "tests/**/*.ts"
   ],
-  "exclude": [],
+  "exclude": [
+    "tests/**/*.ts",
+    "**/__tests__/**/*.ts",
+  ],
   "compilerOptions": {
     // directories
     "declarationDir": "./maps",
-    // "outDir": "./maps",
+    "outDir": "./maps",
     "rootDir": "./",
     // aliases
     "baseUrl": "./",

--- a/packages/@aglabo/agla-logger/configs/eslint.config.js
+++ b/packages/@aglabo/agla-logger/configs/eslint.config.js
@@ -33,7 +33,6 @@ export default [
     ],
     languageOptions: {
       parserOptions: {
-        project: ['./tsconfig.json'],
         tsconfigRootDir: __rootDir,
       },
     },

--- a/packages/@aglabo/agla-logger/configs/eslint.config.typed.js
+++ b/packages/@aglabo/agla-logger/configs/eslint.config.typed.js
@@ -35,7 +35,6 @@ export default [
     languageOptions: {
       parser: tsparser,
       parserOptions: {
-        project: ['./tsconfig.json'],
         tsconfigRootDir: __rootDir,
         sourceType: 'module',
       },

--- a/packages/@aglabo/agla-logger/configs/tsup.config.cjs.ts
+++ b/packages/@aglabo/agla-logger/configs/tsup.config.cjs.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   format: ['cjs'],
   outDir: 'lib', // for CJS
   // tsconfig
-  tsconfig: './tsconfig.json',
+  tsconfig: './tsconfig.build.json',
   // DTS with incremental build for CJS
   dts: false,
 });

--- a/packages/@aglabo/agla-logger/configs/tsup.config.esm.ts
+++ b/packages/@aglabo/agla-logger/configs/tsup.config.esm.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   format: ['esm'],
   outDir: 'module', // for ESM
   // tsconfig
-  tsconfig: './tsconfig.json',
+  tsconfig: './tsconfig.build.json',
   // DTS with incremental build for ESM
   dts: true,
 });

--- a/packages/@aglabo/agla-logger/package.json
+++ b/packages/@aglabo/agla-logger/package.json
@@ -20,7 +20,7 @@
     "build": "pnpm run build:cjs && pnpm run build:esm & pnpm run build:types",
     "build:cjs": "tsup --config ./configs/tsup.config.cjs.ts",
     "build:esm": "tsup --config ./configs/tsup.config.esm.ts",
-    "build:types": "tsc -p ./tsconfig.json",
+    "build:types": "tsc -p ./tsconfig.build.json",
     "clean": "rimraf lib module .cache",
     "format:dprint": "dprint fmt",
     "check:dprint": "dprint check",

--- a/packages/@aglabo/agla-logger/tsconfig.build.json
+++ b/packages/@aglabo/agla-logger/tsconfig.build.json
@@ -10,13 +10,15 @@
   "include": [
     "src/**/*.ts",
     "shared/**/*.ts",
-    "tests/**/*.ts"
   ],
-  "exclude": [],
+  "exclude": [
+    "tests/**/*.ts",
+    "**/__tests__/**/*.ts",
+  ],
   "compilerOptions": {
     // directories
     "declarationDir": "./maps",
-    // "outDir": "./maps",
+    "outDir": "./maps",
     "rootDir": "./",
     // aliases
     "baseUrl": "./",


### PR DESCRIPTION
## ✨ Overview

This Pull Request restructures the TypeScript configuration to clearly separate build, lint, and test concerns.  
The motivation is to **avoid compiling test files into build outputs** while simplifying and aligning toolchain configurations across packages (`agla-error`, `agla-logger`).  

This ensures cleaner builds, easier linting, and more maintainable test environments.

---

## 🔧 Changes

- [x] Added/updated files or modules  
- [ ] Removed deprecated logic or configs  
- [x] Refactored for clarity/performance  
- [ ] Other (please describe below)  

**Details:**
- Added `tsconfig.build.json` to exclude test files during build  
- Updated `package.json` scripts in **agla-error** and **agla-logger** to use `tsconfig.build.json`  
- Adjusted ESLint configs to use `tsconfig.lint.json` and refined parser settings  
- Updated `tsup` configs to reference `tsconfig.build.json` for CJS/ESM builds  
- Simplified Vitest configs with `tsconfig-paths` plugin and removed manual aliases  
- Refined `.gitignore` and project paths for clarity  

---

## 📂 Related Issues

N/A

---

## ✅ Checklist

- [x] Lint checks pass (`pnpm lint`)  
- [x] Tests pass (`pnpm test`)  
- [ ] Documentation is updated (if applicable)  
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)  
- [x] Descriptions and examples are clear  

---

## 💬 Additional Notes

This PR improves **build reliability and test isolation** across the monorepo, preparing for further package integrations.
